### PR TITLE
Fix #4

### DIFF
--- a/main.rb
+++ b/main.rb
@@ -7,7 +7,8 @@ require_relative './yh_scraper'
 module Clockwork
   class << self
     # for test
-    attr_reader :today_str, :ystday_str, :scrp
+    attr_reader :today_year, :today_month, :today_day,
+                :ystday_year, :ystday_month, :ystday_day, :scrp
     attr_accessor :today_updated, :yesterday_updated
 
     TARGET_URL = 'http://www.iryohoken.go.jp/shinryohoshu'
@@ -20,8 +21,12 @@ module Clockwork
 
       today ||= Date.today
       ystday = today - 1
-      @today_str = "#{today.year - 2000 + 12}年#{today.month}月#{today.day}日"
-      @ystday_str = "#{ystday.year - 2000 + 12}年#{ystday.month}月#{ystday.day}日"
+      @today_year = "#{today.year - 2000 + 12}年"
+      @today_month = "#{today.month}月"
+      @today_day = "#{today.day}日"
+      @ystday_year = "#{ystday.year - 2000 + 12}年"
+      @ystday_month = "#{ystday.month}月"
+      @ystday_day = "#{ystday.day}日"
 
       YHMail.report_running unless debug
     end
@@ -48,15 +53,24 @@ module Clockwork
     #   (1) 09:00チェックの時点で、今日00:00 ~ 今日09:00 に更新されたのを検知
     #   (2) 17:00チェックの時点で、今日09:00 ~ 今日17:00 に更新されたのを検知
     def today_has_new_update?
-      f1 = @scrp.text1.include?('医薬品マスター更新') && @scrp.date1.include?(@today_str)
+      f1 = @scrp.text1.include?('医薬品マスター更新') &&
+           @scrp.date1.include?(@today_year) &&
+           @scrp.date1.include?(@today_month) &&
+           @scrp.date1.include?(@today_day)
       f1 && !@today_updated
     end
 
     # 昨日の日付で更新されたのを*初めて*検知した?
     #   (1) 09:00チェックの時点で、昨日17:00 ~ 昨日24:00 に更新されたのを検知
     def yesterday_has_new_update?
-      f1 = @scrp.text1.include?('医薬品マスター更新') && @scrp.date1.include?(@ystday_str)
-      f2 = @scrp.text2.include?('医薬品マスター更新') && @scrp.date2.include?(@ystday_str)
+      f1 = @scrp.text1.include?('医薬品マスター更新') &&
+           @scrp.date1.include?(@ystday_year) &&
+           @scrp.date1.include?(@ystday_month) &&
+           @scrp.date1.include?(@ystday_day)
+      f2 = @scrp.text2.include?('医薬品マスター更新') &&
+           @scrp.date2.include?(@ystday_year) &&
+           @scrp.date2.include?(@ystday_month) &&
+           @scrp.date2.include?(@ystday_day)
       (f1 || f2) && !@yesterday_updated
     end
   end

--- a/spec/fixtures/the_other_dom.html
+++ b/spec/fixtures/the_other_dom.html
@@ -1,0 +1,597 @@
+
+
+
+
+
+
+
+
+
+
+<HTML>
+	<HEAD>
+		<TITLE>診療報酬情報提供サービス</TITLE>
+		<link rel="stylesheet" type="text/css" href="/shinryohoshu/css/shinryo.css">
+		<STYLE type="text/css">
+			<!--
+			h2 {
+				font-size: 14px;
+				border-bottom: solid 2px #666699;
+				padding: 6px 3px 0px 0px;
+				margin: 12px 37px;
+				width: 160px;
+				color: #696969;
+				letter-spacing: 3px
+			}
+			-->
+		</STYLE>
+
+
+
+
+
+
+
+
+<META HTTP-EQUIV="Pragma" CONTENT="no-cache">
+<META HTTP-EQUIV="Cache-Control" CONTENT="no-cache">
+	</HEAD>
+	<BODY bgcolor="#cccccc" leftmargin="0" topmargin="0" bottommargin="0" marginwidth="0" marginheight="0">
+	<TABLE width="850" height="100%" bgcolor="#ffffff" cellpadding="0" cellspacing="0">
+		<TR>
+			<TD valign="top">
+			<TABLE width="100%" height="60" border="0" cellpadding="0" cellspacing="0">
+				<TR>
+					<TD height="75" align="center"><IMG SRC="/shinryohoshu/img/title1.gif" border="0"></TD>
+				</TR>
+			</TABLE>
+			<TABLE width="100%" border="0" cellpadding="0" cellspacing="0">
+				<TR>
+					<TD height="1" bgcolor="#999999"><IMG SRC="/shinryohoshu/img/dummy.gif" width="1" height="1" border="0"></TD>
+				</TR>
+				<TR>
+					<TD height="23">
+						<script language="JavaScript" src="/shinryohoshu/js/menu.js" charset="UTF-8"></script>
+						<script language="JavaScript" src="/shinryohoshu/js/top_pl_menu_items.js"  charset="UTF-8"></script>
+						<script language="JavaScript" src="/shinryohoshu/js/t_menu_tpl.js" charset="UTF-8"></script>
+						<script	language="JavaScript">
+						<!--//
+						new menu(MENU_ITEMS,MENU_POS,MENU_STYLES);
+						//-->
+						</script>
+					</TD>
+				</TR>
+			</TABLE>
+			<TABLE width="100%" border="0" cellpadding="0" cellspacing="0">
+				<TR>
+					<TD height="1" bgcolor="#999999"><IMG SRC="/shinryohoshu/img/dummy.gif"
+						width="1" height="1" border="0"></TD>
+				</TR>
+				<TR>
+					<TD width="100%" height="19" align="right"><FONT class="font12">あなたは11678184人目の訪問者です</font></TD>
+				</TR>
+			</TABLE>
+			<TABLE width="100%" border="0" cellpadding="0" cellspacing="0">
+				<TR>
+					<TD valign="top" class="t" colspan="3" >
+					　　　　診療報酬情報提供サービスは、医療保険請求に関わるレセプト電算処理システムに必要な<BR>
+					　　　　情報をご提供するホームページです。</TD>
+				</TR>
+
+				<TR height="23">
+					<TD class="t" colspan="3"><BR>
+					　　　　<font style="color:#FF0000;">平成27年4月6日より、IPアドレスが変更になりました。</font></TD>
+				</TR>
+
+				<TR height="23">
+					<TD class="t" colspan="3"><BR>
+					　　　　電子点数表につきましては<a href="http://www.ssk.or.jp/tensuhyo/ikashika/index.html" target="_blank" style="color:#FF0000;">社会保険診療報酬支払基金のHP</a>をご覧ください。<BR>
+					　　　　（平成22年12月24日より、電子点数表のURLが変更になりました）</TD>
+				</TR>
+
+				<TR height="23">
+					<TD class="t" colspan="3"><BR>
+					　　　　労災レセプト電算処理システムにつきましては<a href="http://www.mhlw.go.jp/seisakunitsuite/bunya/koyou_roudou/roudoukijun/rousai/rezeptsystem/index.html" target="_blank" style="color:#FF0000;">厚生労働省「労災レセプト電算処理システム」のHP</a>をご覧ください。</TD>
+				</TR>
+
+				<TR>
+					<TD height="5" colspan="3"><IMG SRC="/shinryohoshu/img/dummy.gif" width="1" height="1" border="0"></TD>
+				</TR>
+				<TR>
+					<TD height="1" bgcolor="#666666" colspan="3"><IMG
+						SRC="/shinryohoshu/img/dummy.gif" width="1" height="1" border="0"></TD>
+				</TR>
+				<TR>
+					<TD width="600">
+						<h2><font style="color: #666699;">■</font>　利用のご案内</h2>
+
+						<center>
+						<TABLE border="0" bgcolor="#ffffff" width="490" cellspacing="0"
+							cellpadding="0">
+							<TR>
+								<TD class="t" >　医療保険請求に関わる様々な機関が事務を効率的かつ迅速に行えるよう、各種制度改正情報や点数表、薬価基準などの保険請求に必要な各種の情報や電子レセプト作成のための基本マスターを提供いたします。<BR>
+								　ご利用いただけるサービスは以下の通りです。</TD>
+							</TR>
+						</TABLE>
+						<BR>
+						</center>
+						<IMG src="/shinryohoshu/img/dummy.gif" width="37" height="1" border="0"> <img src="/shinryohoshu/img/menu1.gif">
+						<center>
+						<TABLE border="0" width="470" cellspacing="0" cellpadding="0">
+							<TR height="5">
+								<TD colspan="2">
+									<IMG SRC="/shinryohoshu/img/dummy.gif" width="1" height="1" border="0">
+								</TD>
+							</TR>
+
+							<TR height="23">
+								<TD class="t" nowrap width="170" colspan="2">
+									<a href="/shinryohoshu/infoMenu" style="font-size: 13px;">お知らせ</a>
+								</TD>
+							</TR>
+
+							<TR>
+								<TD><IMG SRC="/shinryohoshu/img/dummy.gif" width="20" height="1" border="0"></TD>
+								<TD class="t">更新履歴、新規サービス追加、メンテナンス作業についてなど、ユーザーの皆様に対するお知らせおよび各種トピックが掲載されています。</TD>
+							</TR>
+
+							<TR height="5">
+								<TD colspan="2">
+									<IMG SRC="/shinryohoshu/img/dummy.gif" width="1" height="1" border="0">
+								</TD>
+							</TR>
+
+							<TR height="23">
+								<TD class="t" nowrap colspan="2">
+									<a href="/shinryohoshu/faq" style="font-size: 13px;">利用上の注意・FAQ</a>
+								</TD>
+							</TR>
+
+							<TR>
+								<TD><IMG SRC="/shinryohoshu/img/dummy.gif" width="20" height="1" border="0"></TD>
+								<TD class="t">このページでは当ホームページに寄せられたよくあるお問合せと、それに対する回答を掲載しています。</TD>
+							</TR>
+
+							<TR height="5">
+								<TD colspan="2">
+									<IMG SRC="/shinryohoshu/img/dummy.gif" width="1" height="1" border="0">
+								</TD>
+							</TR>
+
+							<TR height="23">
+								<TD class="t" nowrap colspan="2">
+									<a href="/shinryohoshu/link" style="font-size: 13px;">リンク</a>
+								</TD>
+							</TR>
+
+							<TR>
+								<TD>
+									<IMG SRC="/shinryohoshu/img/dummy.gif" width="20" height="1" border="0">
+								</TD>
+								<TD class="t">関連団体へのリンク集です。</TD>
+							</TR>
+
+							<TR height="5">
+								<TD colspan="2">
+									<IMG SRC="/shinryohoshu/img/dummy.gif" width="1" height="1" border="0">
+								</TD>
+							</TR>
+
+							<TR height="23">
+								<TD class="t" nowrap colspan="2">
+									<a href="/shinryohoshu/siteMap" style="font-size: 13px;">サイトマップ</a>
+								</TD>
+							</TR>
+
+							<TR>
+								<TD>
+									<IMG SRC="/shinryohoshu/img/dummy.gif" width="20" height="1" border="0">
+								</TD>
+								<TD class="t">本サイトのページ一覧です。</TD>
+							</TR>
+
+							<TR height="10">
+								<TD colspan="2">
+									<IMG SRC="/shinryohoshu/img/dummy.gif" width="1" height="1" border="0">
+								</TD>
+							</TR>
+
+						</TABLE>
+						</center>
+						<IMG src="/shinryohoshu/img/dummy.gif" width="37" height="1" border="0"/>
+						<img src="/shinryohoshu/img/menu2.gif"/>
+						<center>
+						<TABLE border="0" width="470" cellspacing="0" cellpadding="0">
+							<TR height="5">
+								<TD colspan="2">
+									<IMG SRC="/shinryohoshu/img/dummy.gif" width="1" height="1" border="0">
+								</TD>
+							</TR>
+							<TR height="23">
+								<TD class="t" nowrap colspan="2">
+									<a href="/shinryohoshu/receMenu" style="font-size: 13px;">レセプト電算処理システム</a>
+								</TD>
+							</TR>
+							<TR>
+								<TD><IMG SRC="/shinryohoshu/img/dummy.gif" width="20" height="1" border="0"/></TD>
+								<TD class="t">レセプト電算処理システムを導入するメリットや、加入の手続き、Q&amp;Aを掲載しています。<BR>
+								また、レセ電加入に必要な様式をダウンロードすることができます。</TD>
+							</TR>
+							<TR height="5">
+								<TD colspan="2"><IMG SRC="/shinryohoshu/img/dummy.gif" width="1" height="1" border="0"/></TD>
+							</TR><!--
+							<TABLE border="0" width="470" cellspacing="0" cellpadding="0">
+								--><TR height="5">
+									<TD colspan="2"><IMG SRC="/shinryohoshu/img/dummy.gif" width="1" height="1" border="0"/></TD>
+								</TR>
+								<TR height="23">
+									<TD class="t" nowrap colspan="2">
+										<a href="/shinryohoshu/receDentalMenu" style="font-size: 13px;">レセプト電算処理歯科システムに関する情報</a>
+									</TD>
+								</TR>
+
+								<TR>
+									<TD><IMG SRC="/shinryohoshu/img/dummy.gif" width="20" height="1" border="0"></TD>
+									<TD class="t">レセプト電算処理の歯科システムに関する情報を提供しています。<BR>
+									</TD>
+								</TR>
+
+								<TR height="5">
+									<TD colspan="2"><IMG SRC="/shinryohoshu/img/dummy.gif" width="1" height="1" border="0"></TD>
+								</TR>
+								<TR height="23">
+									<TD class="t" nowrap colspan="2">
+										<a href="/shinryohoshu/standardMenu" style="font-size: 13px;">用語・コードの統一</a>
+									</TD>
+								</TR>
+
+								<TR>
+									<TD><IMG SRC="/shinryohoshu/img/dummy.gif" width="20" height="1" border="0"></TD>
+									<TD class="t">医療用語・コードの標準化の目的と現状について説明しています。<BR>
+									改定された傷病名マスターと修飾語マスターのダウンロード・改定に関する情報や、標準化の一環として作成された検査マスターについてもこちらからご覧ください。
+									</TD>
+								</TR>
+
+
+								<TR height="10">
+									<TD colspan="2">
+										<IMG SRC="/shinryohoshu/img/dummy.gif" width="1" height="1" border="0">
+									</TD>
+								</TR>
+							</TABLE>
+							</center>
+							<img src="/shinryohoshu/img/dummy.gif" width="37" height="1" border="0"/>
+							<img src="/shinryohoshu/img/menu3.gif"/>
+							<center>
+							<TABLE border="0" width="470" cellspacing="0" cellpadding="0">
+								<TR height="5">
+									<TD colspan="2">
+										<IMG SRC="/shinryohoshu/img/dummy.gif" width="1" height="1" border="0">
+									</TD>
+								</TR>
+								<TR height="23">
+									<TD class="t" nowrap colspan="2">
+										<a href="/shinryohoshu/paMenu" style="font-size: 13px;">告示･通知に関するご案内</a>
+									</TD>
+								</TR>
+
+								<TR>
+									<TD>
+										<IMG SRC="/shinryohoshu/img/dummy.gif" width="20" height="1" border="0">
+									</TD>
+									<TD class="t">以下の4情報についての各種告示･通知情報を参照できます。<BR>
+										・医科診療行為 ・医薬品 ・特定保険医療材料 ・歯科診療行為</TD>
+								</TR>
+
+								<TR height="5">
+									<TD colspan="2"><IMG SRC="/shinryohoshu/img/dummy.gif" width="1" height="1" border="0"></TD>
+								</TR>
+
+								<TR height="23">
+									<TD class="t" nowrap colspan="2">
+										<a href="/shinryohoshu/kaitei" style="font-size: 13px;">28年度医療費改定</a>
+									</TD>
+								</TR>
+
+								<TR>
+									<TD><IMG SRC="/shinryohoshu/img/dummy.gif" width="20" height="1" border="0"></TD>
+									<TD class="t">28年度医療費改定に対応したマスターをダウンロードすることができます。<BR>
+										またマスターの改定に関する情報が掲載されています。</TD>
+								</TR>
+
+								<TR height="23">
+									<TD class="t" nowrap colspan="2">
+										<a href="/shinryohoshu/kaitei/doKaitei26" style="font-size: 13px;">26年度医療費改定</a>
+									</TD>
+								</TR>
+
+								<TR>
+									<TD><IMG SRC="/shinryohoshu/img/dummy.gif" width="20" height="1" border="0"></TD>
+									<TD class="t">26年度医療費改定に対応したマスターをダウンロードすることができます。<BR>
+										またマスターの改定に関する情報が掲載されています。</TD>
+								</TR>
+
+								<TR height="5">
+									<TD colspan="2"><IMG SRC="/shinryohoshu/img/dummy.gif" width="1" height="1" border="0"></TD>
+								</TR>
+
+								<TR height="23">
+									<TD class="t" nowrap colspan="2">
+										<a href="/shinryohoshu/searchMenu" style="font-size: 13px;">マスター検索</a>
+									</TD>
+								</TR>
+								<TR>
+									<TD><IMG SRC="/shinryohoshu/img/dummy.gif" width="20" height="1" border="0"></TD>
+									<TD class="t">厚生労働省が提供する以下の9種の基本マスター情報を検索、参照することができます。<BR>
+										・医科診療行為 ・医薬品 ・特定保険医療材料<BR>
+										・傷病名 ・修飾語 ・コメント ・歯科診療行為<BR>
+										・歯式 ・調剤行為</TD>
+								</TR>
+
+								<TR height="5">
+									<TD colspan="2"><IMG SRC="/shinryohoshu/img/dummy.gif" width="1" height="1" border="0"></TD>
+								</TR>
+
+								<TR height="23">
+									<TD class="t" nowrap colspan="2">
+										<a href="/shinryohoshu/downloadMenu" style="font-size: 13px;">ファイルダウンロード</a>
+									</TD>
+								</TR>
+
+								<TR>
+									<TD><IMG SRC="/shinryohoshu/img/dummy.gif" width="20" height="1" border="0"></TD>
+									<TD class="t">基本マスターファイルをダウンロードしていただけば、マスターの最新情報をお手持ちのパソコンに簡単に取り込むことができます。</TD>
+								</TR>
+
+								<TR height="10">
+									<TD colspan="2"><IMG SRC="/shinryohoshu/img/dummy.gif" width="1" height="1" border="0"></TD>
+								</TR>
+
+							</TABLE>
+							</center>
+							<IMG src="/shinryohoshu/img/dummy.gif" width="37" height="1" border="0"/>
+							<IMG src="/shinryohoshu/img/menu4.gif"/>
+
+							<center>
+							<TABLE border="0" width="470" cellspacing="0" cellpadding="0">
+								<TR height="5">
+									<TD colspan="2"><IMG SRC="/shinryohoshu/img/dummy.gif" width="1"
+										height="1" border="0"></TD>
+								</TR>
+								<TR height="23">
+									<TD class="t" nowrap colspan="2"><a href="/shinryohoshu/yakuzaiMenu" target="_blank" style="font-size: 13px;">薬剤分類情報閲覧システム</a></TD>
+								</TR>
+								<TR>
+									<TD><IMG SRC="/shinryohoshu/img/dummy.gif" width="20" height="1"
+										border="0"></TD>
+									<TD class="t">新薬の薬価算定にかかる類似薬の選定を図る観点から、効能・効果、薬理作用等に着目し既存品の分類を行ったものです。</TD>
+								</TR>
+							</TABLE>
+							</center>
+							<BR>
+
+
+
+
+
+							</TD>
+							<TD width="1" bgcolor="#666666"><IMG SRC="/shinryohoshu/img/dummy.gif"
+								width="1" height="1" border="0"/></TD>
+							<TD valign="top" bgcolor="#E6E6FA">
+							<center><BR>
+							<div class="news">
+					         <CENTER><BR>
+					            <TABLE bgcolor="#ffffff" border=0 width="210" cellpadding="0" cellspacing="0">
+					              <TR bgcolor="#E6E6FA">
+					                <TD width="210" class="t" colspan="3" background="img/bg_gray.gif" height="25"></TD>
+					              </TR>
+					              <TR>
+					                <TD width="1" bgcolor="#666666"><IMG src="img/dummy.gif" width="1" height="1" border="0"></TD>
+					                <TD>
+					                  <TABLE bgcolor="#ffffff" border=0 width="210" cellpadding="0" cellspacing="0">
+
+										
+										<TR height="10">
+											<TD colspan="2"><IMG src="img/dummy.gif" width="1" height="1" border="0"></TD>
+										</TR>
+
+										<TR>
+											<TD class="t" colspan="2">・28年 1月15日</TD>
+										</TR>
+										<TR>
+											<TD><IMG src="img/dummy.gif" width="15" height="1" border="0"></TD>
+											<TD class="t">	医薬品マスター更新<BR>
+													コメントマスター更新<BR>
+											</TD>
+										</TR>
+										<TR height="10">
+											<TD colspan="2"><IMG src="img/dummy.gif" width="1" height="1" border="0"></TD>
+										</TR>
+
+										<TR>
+											<TD class="t" colspan="2">・28年 1月 5日</TD>
+										</TR>
+										<TR>
+											<TD><IMG src="img/dummy.gif" width="15" height="1" border="0"></TD>
+											<TD class="t">	歯科診療行為マスター更新<BR>
+													コメントマスター更新<BR>
+											</TD>
+										</TR>
+										<TR height="10">
+											<TD colspan="2"><IMG src="img/dummy.gif" width="1" height="1" border="0"></TD>
+										</TR>
+										<TR>
+											<TD class="t" colspan="2">・27年12月28日</TD>
+										</TR>
+										<TR>
+											<TD><IMG src="img/dummy.gif" width="15" height="1" border="0"></TD>
+											<TD class="t">	傷病名マスター更新<BR>
+													修飾語マスター更新<BR>
+													特定器材マスター更新</TD>
+										</TR>
+										<TR height="10">
+											<TD colspan="2"><IMG src="img/dummy.gif" width="1" height="1" border="0"></TD>
+										</TR>
+
+										<TR>
+											<TD class="t" colspan="2">・27年12月10日</TD>
+										</TR>
+										<TR>
+											<TD><IMG src="img/dummy.gif" width="15" height="1" border="0"></TD>
+											<TD class="t">医薬品マスター更新</TD>
+										</TR>
+										<TR height="10">
+											<TD colspan="2"><IMG src="img/dummy.gif" width="1" height="1" border="0"></TD>
+										</TR>
+
+										<TR>
+											<TD class="t" colspan="2">・27年11月27日</TD>
+										</TR>
+										<TR>
+											<TD><IMG src="img/dummy.gif" width="15" height="1" border="0"></TD>
+											<TD class="t">医薬品マスター更新<BR>記録条件仕様更新</TD>
+										</TR>
+										<TR height="10">
+											<TD colspan="2"><IMG src="img/dummy.gif" width="1" height="1" border="0"></TD>
+										</TR>
+										<TR>
+											<TD class="t" colspan="2">・27年11月25日</TD>
+										</TR>
+										<TR>
+											<TD><IMG src="img/dummy.gif" width="15" height="1" border="0"></TD>
+											<TD class="t">医薬品マスター更新</TD>
+										</TR>
+										<TR height="10">
+											<TD colspan="2"><IMG src="img/dummy.gif" width="1" height="1" border="0"></TD>
+										</TR>
+										<TR>
+											<TD class="t" colspan="2">・27年11月20日</TD>
+										</TR>
+										<TR>
+											<TD><IMG src="img/dummy.gif" width="15" height="1" border="0"></TD>
+											<TD class="t">特定器材マスター更新</TD>
+										</TR>
+										<TR height="10">
+											<TD colspan="2"><IMG src="img/dummy.gif" width="1" height="1" border="0"></TD>
+										</TR>
+										<TR>
+											<TD class="t" colspan="2">・27年11月16日</TD>
+										</TR>
+
+										<TR>
+											<TD><IMG src="img/dummy.gif" width="15" height="1" border="0"></TD>
+											<TD class="t">標準仕様に係る別添更新</TD>
+										</TR>
+										<TR height="10">
+											<TD colspan="2"><IMG src="img/dummy.gif" width="1" height="1" border="0"></TD>
+										</TR>
+										<TR>
+											<TD class="t" colspan="2">・27年11月13日</TD>
+										</TR>
+										<TR>
+											<TD><IMG src="img/dummy.gif" width="15" height="1" border="0"></TD>
+											<TD class="t">医薬品マスター更新</TD>
+										</TR>
+
+										<TR height="10">
+								                      <TD colspan="2"><IMG src="img/dummy.gif" width="1" height="1" border="0"></TD>
+										</TR>
+										<TR>
+											<TD class="t" colspan="2">・27年11月11日</TD>
+										</TR>
+										<TR>
+											<TD><IMG src="img/dummy.gif" width="15" height="1" border="0"></TD>
+											<TD class="t">医科診療行為マスター更新</TD>
+										</TR>
+										<TR height="10">
+											<TD colspan="2"><IMG src="img/dummy.gif" width="1" height="1" border="0"></TD>
+										</TR>
+
+					                    <TR>
+					                      <TD colspan="2" bgcolor="#666666"><IMG src="img/dummy.gif" width="1" height="1" border="0"/></TD>
+					                    </TR>
+					                  </TABLE>
+
+					                </TD>
+					                <TD width="1" bgcolor="#666666"><IMG src="img/dummy.gif" width="1" height="1" border="0"/></TD>
+					              </TR>
+
+					            </TABLE>
+
+					            </CENTER>
+					            <BR>
+
+					            <BR>
+
+					            <CENTER>
+					            <TABLE bgcolor="#ffffff" border=0 width="210" cellpadding="0" cellspacing="0">
+					              <TR bgcolor="#E6E6FA">
+					                <TD width="210" class="t" colspan="3" background="/shinryohoshu/img/bg_gray2.gif" height="25"></TD>
+					              </TR>
+					              <TR>
+					                <TD width="1" bgcolor="#666666"><IMG src="/shinryohoshu/img/dummy.gif" width="1" height="1" border="0"></TD>
+					                <TD>
+
+					                  <TABLE border=0 bgcolor="#ffffff" width="210" cellpadding="0" cellspacing="0">
+					                    <TR height="10">
+					                      <TD colspan="2"><IMG src="/shinryohoshu/img/dummy.gif" width="1" height="1" border="0"></TD>
+					                    </TR>
+
+					                    <TR>
+					                      <TD class="t" colspan="2">&nbsp;</TD>
+					                    </TR>
+					                    <TR>
+
+					                      <TD><IMG src="/shinryohoshu/img/dummy.gif" width="10" height="1" border="0"></TD>
+					                      <TD class="t">&nbsp;</TD>
+					                    </TR>
+					                    <TR height="10">
+					                      <TD colspan="2"><IMG src="/shinryohoshu/img/dummy.gif" width="1" height="1" border="0"></TD>
+					                    </TR>
+
+					                    <TR>
+					                      <TD colspan="2" bgcolor="#666666"><IMG src="/shinryohoshu/img/dummy.gif" width="1" height="1" border="0"></TD>
+
+					                    </TR>
+					                  </TABLE>
+
+					                </TD>
+					                <TD width="1" bgcolor="#666666"><IMG src="/shinryohoshu/img/dummy.gif" width="1" height="1" border="0"></TD>
+					              </TR>
+					            </TABLE>
+					            </CENTER>
+					            <BR>
+						   </div></center>
+							</TD>
+							</TR>
+						</TABLE>
+						<TABLE border="0" cellspacing="0" cellpadding="0" width="100%">
+							<TR>
+								<TD height="1" bgcolor="#666666" colspan=2><IMG SRC="/shinryohoshu/img/dummy.gif" width="1" height="1" border="0"></TD>
+							</TR>
+
+							<TR>
+								<TD bgcolor="#FFF0F5" height="22" align="left" class="t">
+									　<a href="/shinryohoshu/siteMap" style="font-size: 13px;">サイトマップ</a>
+								</TD>
+								<TD bgcolor="#FFF0F5" height="22" align="right" class="t">
+									《お問合せについて》　マスターに関するお問合せにつきましては<a href="/shinryohoshu/faq">FAQ</a>をご覧ください
+								</TD>
+							</TR>
+
+							<TR>
+								<TD height="1" bgcolor="#000000" colspan=2><IMG SRC="/shinryohoshu/img/dummy.gif" width="1" height="1" border="0"></TD>
+							</TR>
+							<TR>
+								<TD class="t" align="right" colspan=2>All Rights Reserved. Ministry of
+								Health, Labour and Welfare<BR>
+								当ホームページは厚生労働省保険局が運用しています<BR>
+								</TD>
+							</TR>
+						</TABLE>
+					</TD>
+					<TD width="1" bgcolor="#999999"><IMG SRC="/shinryohoshu/img/dummy.gif" width="1" height="1" border="0"></TD>
+				</TR>
+		</TABLE>
+	</BODY>
+</HTML>

--- a/spec/fixtures/yesterday.html
+++ b/spec/fixtures/yesterday.html
@@ -361,7 +361,7 @@
 					                  <TABLE bgcolor="#ffffff" border=0 width="210" cellpadding="0" cellspacing="0">
 
 										<TR>
-											<TD class="t" colspan="2">・27年12月9日</TD>
+											<TD class="t" colspan="2">・27年12月 9日</TD>
 										</TR>
 										<TR>
 											<TD><IMG src="img/dummy.gif" width="15" height="1" border="0"></TD>

--- a/spec/main_spec.rb
+++ b/spec/main_spec.rb
@@ -4,8 +4,12 @@ RSpec.describe 'YamashitaHelper' do
   describe '#daily_init' do
     it 'should create today and yesterday string' do
       Clockwork.daily_init(Date.new(2015, 01, 01), true)
-      expect(Clockwork.today_str).to eq('27年1月1日')
-      expect(Clockwork.ystday_str).to eq('26年12月31日')
+      expect(Clockwork.today_year).to eq('27年')
+      expect(Clockwork.today_month).to eq('1月')
+      expect(Clockwork.today_day).to eq('1日')
+      expect(Clockwork.ystday_year).to eq('26年')
+      expect(Clockwork.ystday_month).to eq('12月')
+      expect(Clockwork.ystday_day).to eq('31日')
     end
 
     it 'should init today_updated' do
@@ -74,6 +78,25 @@ RSpec.describe 'YamashitaHelper' do
         expect(Clockwork.today_updated).to be_falsey
         expect(Clockwork.yesterday_updated).to be_falsey
         expect(Clockwork.scrp.dom_changed?).to be_truthy
+      end
+    end
+  end
+
+  # 監視先サイトのHTML構造が変わっている場合 (それでも検知しないといけない)
+  describe '#check_site to the other dom' do
+    before(:each) do
+      Clockwork.today_updated = false
+      Clockwork.yesterday_updated = false
+      Clockwork.daily_init(Date.new(2016, 1, 15), true)
+    end
+
+    # today -> 2016/01/15
+    context 'page updated today' do
+      it 'should detect update' do
+        Clockwork.check_site('./spec/fixtures/the_other_dom.html', true)
+        expect(Clockwork.today_updated).to be_truthy
+        expect(Clockwork.yesterday_updated).to be_falsey
+        expect(Clockwork.scrp.dom_changed?).to be_falsey
       end
     end
   end

--- a/yh_scraper.rb
+++ b/yh_scraper.rb
@@ -15,12 +15,21 @@ class YHScraper
     elms = doc.xpath(UPDATE_HISTORY_TABLE_XPATH)
 
     # 過去2回分の更新を取得
-    @date1 = elms[0].xpath('./td').first.content
-    @text1 = elms[1].xpath('./td')[1].content
-    @date2 = elms[3].xpath('./td').first.content
-    @text2 = elms[4].xpath('./td')[1].content
-  rescue
-    @cannot_scrape = true
+    begin
+      @date1 = elms[0].xpath('./td')[0].content
+      @text1 = elms[1].xpath('./td')[1].content
+      @date2 = elms[3].xpath('./td')[0].content
+      @text2 = elms[4].xpath('./td')[1].content
+    rescue
+      begin
+        @date1 = elms[1].xpath('./td')[0].content
+        @text1 = elms[2].xpath('./td')[1].content
+        @date2 = elms[4].xpath('./td')[0].content
+        @text2 = elms[5].xpath('./td')[1].content
+      rescue
+        @cannot_scrape = true
+      end
+    end
   end
 
   def dom_changed?


### PR DESCRIPTION
ref: https://github.com/showwin/YamashitaHelper/issues/4
- 対象ページのHTML構造が時々変わることによって、変更が検知できないバグ修正
- 追加で、日付の表記ゆれに対応 (`28年 1月 9日` だったり `28年1月9日` だったりした)
